### PR TITLE
Some changes during review

### DIFF
--- a/code/Dockerfile
+++ b/code/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y curl 
 # remove policy to disable PDF conversion
 RUN rm /etc/ImageMagick-6/policy.xml
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python3
-RUN python3 -m pip install flask "Beautifulsoup4<4.12" lxml Markdown gunicorn pysolr pydot tabulate hilbertcurve==1.0.5 markdown-it-py==1.1.0 deepdiff redis "pyparsing<3" networkx xmlschema solrq polib
+RUN python3 -m pip install flask "Beautifulsoup4<4.12" lxml Markdown gunicorn pysolr pydot tabulate hilbertcurve==1.0.5 markdown-it-py==1.1.0 deepdiff redis "pyparsing<3" networkx xmlschema solrq polib babel
 
 RUN curl --location --silent --show-error --retry 5 'https://archive.apache.org/dist/lucene/solr/8.6.3/solr-8.6.3.tgz' -o - | tar zxf -
 RUN chmod +x /solr-8.6.3/bin/*

--- a/code/create_resources.sh
+++ b/code/create_resources.sh
@@ -7,3 +7,4 @@ python3 change_log.py ..
 python3 parse_examples.py ..
 python3 templates_to_mvdxml.py IFC4.3.mvdxml
 python3 determine_mvd_scope.py IFC.exp IFC4.3.mvdxml
+# python3 translate.py build-cache

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -11,3 +11,4 @@ pydot
 pysolr
 tabulate
 polib
+babel

--- a/code/server.py
+++ b/code/server.py
@@ -55,8 +55,10 @@ app = Flask(__name__)
 app.jinja_env.trim_blocks = True
 app.jinja_env.lstrip_blocks = True
 
-is_iso = os.environ.get('ISO', '0') == '1'
-is_package = os.environ.get('PACKAGE', '0') == '1'
+truthy = lambda s: (s or '').strip().lower() not in ('', '0', 'false', 'no', 'off')
+
+is_iso = truthy(os.environ.get('ISO'))
+is_package = truthy(os.environ.get('PACKAGE'))
 if is_package:
     base = "/HTML"
 else:
@@ -1077,8 +1079,8 @@ def resource(resource):
                 break
         
             
-            cached_html = html_cache_manager.get_cached_html(resource)
-            if not eval(os.environ.get('TRANSLATION_UPDATING')) and cached_html:
+            cached_html = None # html_cache_manager.get_cached_html(resource)
+            if not truthy(os.environ.get('TRANSLATION_UPDATING')) and cached_html:
                 return cached_html
             
             # generate and write the html to the cache in case we're crawling the urls or there is no cached html yet
@@ -1114,8 +1116,8 @@ def resource(resource):
         
     elif resource in R.pset_definitions.keys():
         html_cache_manager = HTMLCacheManager('properties')
-        cached_html = html_cache_manager.get_cached_html(resource)
-        if not eval(os.environ.get('TRANSLATION_UPDATING')) and cached_html:
+        cached_html = None # html_cache_manager.get_cached_html(resource)
+        if not truthy(os.environ.get('TRANSLATION_UPDATING')) and cached_html:
             return cached_html
         
         translator = CrowdinTranslator()
@@ -1139,8 +1141,8 @@ def resource(resource):
         return rendered_html
     
     html_cache_manager = HTMLCacheManager('types')
-    cached_html = html_cache_manager.get_cached_html(resource)
-    if not eval(os.environ.get('TRANSLATION_UPDATING')) and cached_html:
+    cached_html = None # html_cache_manager.get_cached_html(resource)
+    if not truthy(os.environ.get('TRANSLATION_UPDATING')) and cached_html:
         return cached_html
     
     builder = resource_documentation_builder(resource)

--- a/code/templates/entity.html
+++ b/code/templates/entity.html
@@ -4,7 +4,6 @@
 <h1>{{ number }} {{ entity }}</h1>
 <p>
     <aside class="aside-note">
-        <mark>TRANSLATION</mark>
         {% for lang, data in translations.items() %}
         <div class="translation lang-{{ lang }}">
             <div>

--- a/code/templates/main.html
+++ b/code/templates/main.html
@@ -30,41 +30,37 @@
                 {% endif %}
                 
                 {% if not is_iso %}
-                <!-- WIP; adjust to the BSI Styling and/or insert nicer button -->
-                <div style="float: left; margin-left: 80px;">
-                    <label for="language-selector" style="font-weight: bold; margin-right: 10px;"></label>
-                    <select id="language-selector" onchange="setLanguagePreference(this.value)" style="border: none; background: none; color: inherit;">
-                        <option value="English_UK" selected>🇬🇧 English</option>
-                        <option value="Arabic">🇸🇦 Arabic</option>
-                        <option value="Chinese Simplified">🇨🇳 Chinese</option>
-                        <option value="Croatian">🇭🇷 Croatian</option>
-                        <option value="Czech">🇨🇿 Czech</option>
-                        <option value="Danish">🇩🇰 Danish</option>
-                        <option value="Dutch">🇳🇱 Dutch</option>
-                        <option value="English">🇺🇸 English (US)</option>
-                        <option value="Finnish">🇫🇮 Finnish</option>
-                        <option value="French">🇫🇷 French</option>
-                        <option value="German">🇩🇪 German</option>
-                        <option value="Hindi">🇮🇳 Hindi</option>
-                        <option value="Icelandic">🇮🇸 Icelandic</option>
-                        <option value="Italian">🇮🇹 Italian</option>
-                        <option value="Japanese">🇯🇵 Japanese</option>
-                        <option value="Korean">🇰🇷 Korean</option>
-                        <option value="Lithuanian">🇱🇹 Lithuanian</option>
-                        <option value="Norwegian">🇳🇴 Norwegian</option>
-                        <option value="Polish">🇵🇱 Polish</option>
-                        <option value="Portuguese">🇵🇹 Portuguese</option>
-                        <option value="Portuguese_Brazilian">🇧🇷 Portuguese (Brazilian)</option>
-                        <option value="Romanian">🇷🇴 Romanian</option>
-                        <option value="Slovenian">🇸🇮 Slovenian</option>
-                        <option value="Spanish">🇪🇸 Spanish</option>
-                        <option value="Swedish">🇸🇪 Swedish</option>
-                        <option value="Turkish">🇹🇷 Turkish</option>
-                    </select>
-                </div>
-            
-            
                 <ul>
+                    <li>
+                        <select id="language-selector" onchange="setLanguagePreference(this.value)" style="border: none; background: none; color: inherit;">
+                            <option value="English_UK" selected>🇬🇧 English</option>
+                            <option value="Arabic">🇸🇦 Arabic</option>
+                            <option value="Chinese Simplified">🇨🇳 Chinese</option>
+                            <option value="Croatian">🇭🇷 Croatian</option>
+                            <option value="Czech">🇨🇿 Czech</option>
+                            <option value="Danish">🇩🇰 Danish</option>
+                            <option value="Dutch">🇳🇱 Dutch</option>
+                            <option value="English">🇺🇸 English (US)</option>
+                            <option value="Finnish">🇫🇮 Finnish</option>
+                            <option value="French">🇫🇷 French</option>
+                            <option value="German">🇩🇪 German</option>
+                            <option value="Hindi">🇮🇳 Hindi</option>
+                            <option value="Icelandic">🇮🇸 Icelandic</option>
+                            <option value="Italian">🇮🇹 Italian</option>
+                            <option value="Japanese">🇯🇵 Japanese</option>
+                            <option value="Korean">🇰🇷 Korean</option>
+                            <option value="Lithuanian">🇱🇹 Lithuanian</option>
+                            <option value="Norwegian">🇳🇴 Norwegian</option>
+                            <option value="Polish">🇵🇱 Polish</option>
+                            <option value="Portuguese">🇵🇹 Portuguese</option>
+                            <option value="Portuguese_Brazilian">🇧🇷 Portuguese (Brazilian)</option>
+                            <option value="Romanian">🇷🇴 Romanian</option>
+                            <option value="Slovenian">🇸🇮 Slovenian</option>
+                            <option value="Spanish">🇪🇸 Spanish</option>
+                            <option value="Swedish">🇸🇪 Swedish</option>
+                            <option value="Turkish">🇹🇷 Turkish</option>
+                        </select>
+                    </li>
                     <li>
                         {% if is_package %}
                             <a href="https://technical.buildingsmart.org/standards/ifc/ifc-schema-specifications/">

--- a/code/templates/property.html
+++ b/code/templates/property.html
@@ -5,7 +5,6 @@
 
 <p>
     <aside class="aside-note">
-        <mark>TRANSLATION</mark>
         {% for lang, data in translations.items() %}
         <div class="translation lang-{{ lang }}">
             <div>

--- a/code/translate.py
+++ b/code/translate.py
@@ -75,7 +75,7 @@ def build_language_file_map():
 def compile_po_to_mo(po_file_path, mo_file_path):
     """Compile the .po file to a .mo file using msgfmt (external gettext utility)."""
     try:
-        subprocess.run(['msgfmt', po_file_path, '-o', mo_file_path], check=True)
+        subprocess.run(['pybabel', 'compile', '-i', po_file_path, '-o', mo_file_path], check=True)
         return mo_file_path
     except subprocess.CalledProcessError as e:
         print(f"Error compiling {po_file_path} to .mo: {e}")

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -33,7 +33,10 @@ header ul>li {
     padding-left: calc(2 * var(--universal-padding));
     padding-right: calc(2 * var(--universal-padding));
 }
-header ul>li a svg {
+header select, header label {
+   color: var(--a-link-color);
+}
+header ul>li svg {
     vertical-align: middle;
     width: 16px;
     height: 16px;

--- a/docs/assets/js/app.js
+++ b/docs/assets/js/app.js
@@ -348,19 +348,19 @@ function getCookie(name) {
     return null;
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+function filterActiveLanguage() {
     const languagePreference = getCookie('languagePreference') || 'English_UK';
     console.log("Language Preference:", languagePreference);
 
-    const activeTranslations = document.querySelectorAll(`.lang-${languagePreference}`);
-    console.log("Active translations found:", activeTranslations.length);
+    const translations = document.querySelectorAll(`div.translation`);
+    console.log("Active translations found:", ...Array.from(translations).map(el => el.className));
 
-    activeTranslations.forEach((translation) => {
-        console.log("Setting display:block for:", translation.className);
-        translation.style.display = 'block';
+    translations.forEach((translation) => {
+        translation.style.display = translation.classList.contains(`lang-${languagePreference}`) ? 'block' : 'none';
     });
-});
+}
 
+document.addEventListener("DOMContentLoaded", filterActiveLanguage);
 
 function setLanguagePreference(value) {
     let languageMapping = {
@@ -397,5 +397,5 @@ function setLanguagePreference(value) {
     var expires = "; expires=" + date.toUTCString();
 
     document.cookie = `languagePreference=${value}${expires}; path=/;`;
-    location.reload();
+    filterActiveLanguage();
 }


### PR DESCRIPTION
Some changes that I needed to get things running:

- Support windows (msgfmt -> babel, utf-8, ...)
- eliminated the need for page reload to switch language
- tweaked style
- updated some defaults to point to the submodule

### Todo

- we have to disable caching, we cannot cache based on translations alone because the .md files can also change, we'll implement caching later on using a separate reverse proxy
- create .mo files in create_resources for easy get started
- create .mo files using multiple threads
- When there is no translation, don't show an empty aside but rather show that there are no translations for this language and a link how to contribute.
- Generate the language-selector options from the dictionary in Python, and remove the dict in JS (it's not used)
- `Chinese Simplified` has a space, this most likely brakes the classname, it's the only one. (but this is hopefully solved by autogenerating the options.

### Questions

- I really don't understand load_original() this seems really inefficient and I don't know what it does. Related to that I don't understand why we have both TRANSLATIONS_DIR and CROWDIN_REPO_DIR, I don't know what to initialize these to. I see there is only one submodule initialized.