### PR TITLE
TM16B - editorial layer (normalized PEnum tail + LoadBearing rename)

### DIFF
--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcArchElement.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcArchElement.md
@@ -1,0 +1,16 @@
+# IfcArchElement
+
+A typically curved structural member spanning an opening and serving as a support.
+<!-- end of short definition -->
+
+> NOTE Subtype of _IfcBuiltElement_ — see that entity's documentation for inherited attributes and behavior.
+
+> HISTORY New entity in IFC 4.4.
+
+## Attributes
+
+### PredefinedType
+Specifies the type for which the value is selected from a predefined type enumeration. This type may associate additional specific property sets.
+
+> NOTE  The _PredefinedType_ shall only be used, if no _IfcArchElementType_ is assigned, providing its own _IfcArchElementType.PredefinedType_.
+

--- a/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcArchElementType.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Entities/IfcArchElementType.md
@@ -1,0 +1,23 @@
+# IfcArchElementType
+
+The element type _IfcArchElementType_ defines commonly shared information for occurrences of arch elements. Arch elements are building elements which represent unitary curved structures. The set of shared information may include:
+
+* common properties within shared property sets
+* common material information
+* common profile definitions
+* common shape representations
+
+It is used to define an arch element specification that is common to all occurrences of that arch element type. Arch element types may be exchanged without being already assigned to occurrences.
+
+Occurrences of the _IfcArchElementType_ within building models are represented by instances of _IfcArchElement_.
+<!-- end of short definition -->
+
+> NOTE Subtype of _IfcBuiltElementType_ — see that entity's documentation for inherited attributes and behavior.
+
+> HISTORY New entity in IFC 4.4.
+
+## Attributes
+
+### PredefinedType
+Specifies the type for which the value is selected from a predefined type enumeration.
+

--- a/docs/schemas/shared/IfcSharedBldgElements/PropertyEnumerations/PEnum_BoltType.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/PropertyEnumerations/PEnum_BoltType.md
@@ -1,0 +1,48 @@
+# PEnum_BoltType
+
+This enumeration defines the predefined types of <!-- FILL IN: which entity uses this enum -->.
+<!-- end of short definition -->
+
+> HISTORY New enumeration in IFC 4.4.
+
+## Items
+
+### GROUTED
+<!-- FILL IN: description of GROUTED. -->
+
+### ANCHORED
+<!-- FILL IN: description of ANCHORED. -->
+
+### ANCHORED_WITH_EXPANSION_CASING
+<!-- FILL IN: description of ANCHORED_WITH_EXPANSION_CASING. -->
+
+### COMBINATION
+<!-- FILL IN: description of COMBINATION. -->
+
+### FRICTION
+<!-- FILL IN: description of FRICTION. -->
+
+### FITTING
+<!-- FILL IN: description of FITTING. -->
+
+### CABLE
+<!-- FILL IN: description of CABLE. -->
+
+### WIRE
+<!-- FILL IN: description of WIRE. -->
+
+### SELFDRILLING
+<!-- FILL IN: description of SELFDRILLING. -->
+
+### GLASS_FIBRE_REINFORCED_PLASTICS
+<!-- FILL IN: description of GLASS_FIBRE_REINFORCED_PLASTICS. -->
+
+### OTHER
+<!-- FILL IN: description of OTHER. -->
+
+### NOTKNOWN
+Value is unkown
+
+### UNSET
+Value has not been specified
+

--- a/docs/schemas/shared/IfcSharedBldgElements/PropertyEnumerations/PEnum_SegmentJointType.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/PropertyEnumerations/PEnum_SegmentJointType.md
@@ -1,0 +1,30 @@
+# PEnum_SegmentJointType
+
+Enumeration different joint types for arch segments used for rings and arches.
+<!-- end of short definition -->
+
+> HISTORY New enumeration in IFC 4.4.
+
+## Items
+
+### FLAT
+Flat joint connecting 2 rings segments or arches.
+
+### TONGUE_GROOVE
+Joint of type Tongue-Groove connecting 2 rings segments or arches.
+
+### CONVEX_CONVEX
+Joint of type Convex-Convex connecting 2 rings segments or arches.
+
+### CONCAVE_CONVEX
+Joint of type Concave-Convex connecting 2 rings segments or arches.
+
+### OTHER
+<!-- FILL IN: description of OTHER. -->
+
+### NOTKNOWN
+Value is unkown
+
+### UNSET
+Value has not been specified
+

--- a/docs/schemas/shared/IfcSharedBldgElements/PropertySets/Pset_ArchElementCommon.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/PropertySets/Pset_ArchElementCommon.md
@@ -1,0 +1,24 @@
+# Pset_ArchElementCommon
+
+Properties common to all types of _IfcArchElement_.
+<!-- end of short definition -->
+
+> HISTORY New entity in IFC 4.4.
+
+## Attributes
+
+### CentroidRadius
+The centroid radius of the element.
+
+### InnerRadius
+The inner radius of the element.
+
+### LoadBearing
+<!-- FILL IN: description of LoadBearing (IfcBoolean). -->
+
+### OuterRadius
+The outer radius of the element.
+
+### Thickness
+The geometric thickness of the object.
+

--- a/docs/schemas/shared/IfcSharedBldgElements/PropertySets/Pset_ArchElementTypeSegment.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/PropertySets/Pset_ArchElementTypeSegment.md
@@ -1,0 +1,24 @@
+# Pset_ArchElementTypeSegment
+
+Properties for arch elements of type SEGMENT.
+<!-- end of short definition -->
+
+> HISTORY New entity in IFC 4.4.
+
+## Attributes
+
+### LongitudinalJointConnections
+Specified if particular connector, e.g. guiding rod, is used.
+
+### LongitudinalJointType
+Type of longitudinal joint.
+
+### Mountings
+Specifies any mountings inserted in segment.
+
+### RadialJointConnections
+Specified if particular connector, e.g. dowel, is used.
+
+### RadialJointType
+Type of radial joint.
+

--- a/docs/schemas/shared/IfcSharedBldgElements/PropertySets/Pset_ArchElementTypeSteelRib.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/PropertySets/Pset_ArchElementTypeSteelRib.md
@@ -1,0 +1,33 @@
+# Pset_ArchElementTypeSteelRib
+
+Properties for arch elements of type _STEELRIB_.
+<!-- end of short definition -->
+
+> HISTORY New entity in IFC 4.4.
+
+## Attributes
+
+### ApertureAngle
+Specifies the angle from which an arch rises.
+
+### BoltLength
+Length of the bolt. When there is a solid geometry from which the length can be derived, the geometric representation takes precedence.
+
+### BoltType
+Specifies the type of bolts used for the steel rib.
+
+### CorrosionTreatmentBolt
+Specifies the corrosion treatment for the bolts.
+
+### FootOfArches
+Specifies the type of vertical structure upon which the lower part of the arch leans onto.
+
+### LongitudinalConnections
+Specifies the type of steel profiles that connect ribs longitudinally.
+
+### LongitudinalSpacing
+Longitudinal spacing between steel ribs.
+
+### ReticularArchType
+Specifies the type when the arch is made of interlaced profiles.
+

--- a/docs/schemas/shared/IfcSharedBldgElements/QuantitySets/Qto_ArchElementBaseQuantities.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/QuantitySets/Qto_ArchElementBaseQuantities.md
@@ -1,0 +1,28 @@
+# Qto_ArchElementBaseQuantities
+
+Base quantities that are common to the definition of all occurrences of arch elements.
+<!-- end of short definition -->
+
+> HISTORY New entity in IFC 4.4.
+
+## Attributes
+
+### CrossSectionArea
+The cross section area of the arch element.
+
+### InnerSurfaceArea
+The inner surface area of the arch element.
+
+### Length
+The length of the object.
+
+The axis arch length from the profile center of gravity.
+
+### OuterSurfaceArea
+The outer surface area of the arch element.
+
+### Volume
+Volume of the element.
+
+Total volume of the arch element.
+

--- a/docs/schemas/shared/IfcSharedBldgElements/Types/IfcArchElementTypeEnum.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Types/IfcArchElementTypeEnum.md
@@ -1,0 +1,24 @@
+# IfcArchElementTypeEnum
+
+This enumeration defines the different types of elements an _IfcArchElement_ or _IfcArchElementType_ object can be defined as.
+<!-- end of short definition -->
+
+> HISTORY New enumeration in IFC 4.4.
+
+## Items
+
+### SEGMENT
+An arch element segment typically part of a larger _IfcElementAssembly_ of type _ARCH_ or _RING_.
+
+### LINING
+An arch element used for lining inside curved structures, e.g using sprayed concrete or similar methods.
+
+### STEELRIB
+Reinforcement cages or steel profiles are shaped as arcs along the rock perimeter of the tunnel.
+
+### USERDEFINED
+User-defined type.
+
+### NOTDEFINED
+Undefined type.
+

--- a/schemas/IfcSharedBldgElements.uml
+++ b/schemas/IfcSharedBldgElements.uml
@@ -3438,5 +3438,210 @@ OR
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_StairFlightBaseQuantities_IfcStairFlight" client="cl_Qto_StairFlightBaseQuantities" supplier="cl_IfcStairFlight"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_WallBaseQuantities_IfcWall" client="cl_Qto_WallBaseQuantities" supplier="cl_IfcWall"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_WindowBaseQuantities_IfcWindow" client="cl_Qto_WindowBaseQuantities" supplier="cl_IfcWindow"/>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_IfcArchElementTypeEnum" name="IfcArchElementTypeEnum">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcArchElementTypeEnum_SEGMENT" name="SEGMENT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcArchElementTypeEnum_LINING" name="LINING"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcArchElementTypeEnum_STEELRIB" name="STEELRIB"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcArchElementTypeEnum_USERDEFINED" name="USERDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcArchElementTypeEnum_NOTDEFINED" name="NOTDEFINED"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcArchElement" name="IfcArchElement">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElement_gen_IfcBuiltElement">
+        <general xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcBuiltElement"/>
+      </generalization>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcArchElement_PredefinedType" name="PredefinedType" type="en_IfcArchElementTypeEnum">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcArchElement_PredefinedType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcArchElement_PredefinedType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcArchElementType" name="IfcArchElementType">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementType_gen_IfcBuiltElementType">
+        <general xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcBuiltElementType"/>
+      </generalization>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcArchElementType_PredefinedType" name="PredefinedType" type="en_IfcArchElementTypeEnum">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcArchElementType_PredefinedType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcArchElementType_PredefinedType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcArchElementTypeEnum_SEGMENT" name="IfcArchElementTypeEnum.SEGMENT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_SEGMENT_gen_IfcArchElement" general="cl_IfcArchElement"/>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_SEGMENT_gen_IfcArchElementType" general="cl_IfcArchElementType"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcArchElementTypeEnum_LINING" name="IfcArchElementTypeEnum.LINING">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_LINING_gen_IfcArchElement" general="cl_IfcArchElement"/>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_LINING_gen_IfcArchElementType" general="cl_IfcArchElementType"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcArchElementTypeEnum_STEELRIB" name="IfcArchElementTypeEnum.STEELRIB">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_STEELRIB_gen_IfcArchElement" general="cl_IfcArchElement"/>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_STEELRIB_gen_IfcArchElementType" general="cl_IfcArchElementType"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcArchElementTypeEnum_USERDEFINED" name="IfcArchElementTypeEnum.USERDEFINED">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_USERDEFINED_gen_IfcArchElement" general="cl_IfcArchElement"/>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_USERDEFINED_gen_IfcArchElementType" general="cl_IfcArchElementType"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcArchElementTypeEnum_NOTDEFINED" name="IfcArchElementTypeEnum.NOTDEFINED">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_NOTDEFINED_gen_IfcArchElement" general="cl_IfcArchElement"/>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcArchElementTypeEnum_NOTDEFINED_gen_IfcArchElementType" general="cl_IfcArchElementType"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_ArchElementTypeSegment" name="Pset_ArchElementTypeSegment">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_ArchElementTypeSegment_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSegment_LongitudinalJointConnections" name="LongitudinalJointConnections">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSegment_LongitudinalJointConnections_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSegment_LongitudinalJointConnections_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSegment_LongitudinalJointType" name="LongitudinalJointType" type="en_PEnum_SegmentJointType">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSegment_LongitudinalJointType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSegment_LongitudinalJointType_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSegment_Mountings" name="Mountings">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSegment_Mountings_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSegment_Mountings_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSegment_RadialJointConnections" name="RadialJointConnections">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSegment_RadialJointConnections_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSegment_RadialJointConnections_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSegment_RadialJointType" name="RadialJointType" type="en_PEnum_SegmentJointType">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSegment_RadialJointType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSegment_RadialJointType_upper" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_SegmentJointType" name="PEnum_SegmentJointType">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_SegmentJointType_FLAT" name="FLAT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_SegmentJointType_TONGUE_GROOVE" name="TONGUE_GROOVE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_SegmentJointType_CONVEX_CONVEX" name="CONVEX_CONVEX"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_SegmentJointType_CONCAVE_CONVEX" name="CONCAVE_CONVEX"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_SegmentJointType_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_SegmentJointType_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_SegmentJointType_UNSET" name="UNSET"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_ArchElementTypeSegment_IfcArchElementTypeEnum.SEGMENT" client="cl_Pset_ArchElementTypeSegment" supplier="cl_IfcArchElementTypeEnum_SEGMENT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_ArchElementCommon" name="Pset_ArchElementCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_ArchElementCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementCommon_CentroidRadius" name="CentroidRadius">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementCommon_CentroidRadius_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementCommon_CentroidRadius_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementCommon_InnerRadius" name="InnerRadius">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementCommon_InnerRadius_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementCommon_InnerRadius_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementCommon_IsLoadBearing" name="LoadBearing">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcBoolean"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementCommon_IsLoadBearing_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementCommon_IsLoadBearing_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementCommon_OuterRadius" name="OuterRadius">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementCommon_OuterRadius_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementCommon_OuterRadius_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementCommon_Thickness" name="Thickness">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementCommon_Thickness_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementCommon_Thickness_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_ArchElementCommon_IfcArchElement" client="cl_Pset_ArchElementCommon" supplier="cl_IfcArchElement"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_ArchElementTypeSteelRib" name="Pset_ArchElementTypeSteelRib">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_ArchElementTypeSteelRib_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_ApertureAngle" name="ApertureAngle">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_ApertureAngle_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_ApertureAngle_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_BoltLength" name="BoltLength">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_BoltLength_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_BoltLength_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_BoltType" name="BoltType" type="en_PEnum_BoltType">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_BoltType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_BoltType_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_CorrosionTreatmentBolt" name="CorrosionTreatmentBolt">
+        <type xmi:type="uml:Enumeration" href="IfcSharedComponentElements.uml#en_PEnum_ElementComponentCorrosionTreatment"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_CorrosionTreatmentBolt_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_CorrosionTreatmentBolt_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_FootOfArches" name="FootOfArches">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_FootOfArches_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_FootOfArches_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_LongitudinalConnections" name="LongitudinalConnections">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_LongitudinalConnections_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_LongitudinalConnections_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_LongitudinalSpacing" name="LongitudinalSpacing">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_LongitudinalSpacing_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_LongitudinalSpacing_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_ArchElementTypeSteelRib_ReticularArchType" name="ReticularArchType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_ArchElementTypeSteelRib_ReticularArchType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_ArchElementTypeSteelRib_ReticularArchType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_BoltType" name="PEnum_BoltType">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_GROUTED" name="GROUTED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_ANCHORED" name="ANCHORED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_ANCHORED_WITH_EXPANSION_CASING" name="ANCHORED_WITH_EXPANSION_CASING"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_COMBINATION" name="COMBINATION"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_FRICTION" name="FRICTION"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_FITTING" name="FITTING"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_CABLE" name="CABLE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_WIRE" name="WIRE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_SELFDRILLING" name="SELFDRILLING"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_GLASS_FIBRE_REINFORCED_PLASTICS" name="GLASS_FIBRE_REINFORCED_PLASTICS"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_BoltType_UNSET" name="UNSET"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_ArchElementTypeSteelRib_IfcArchElementTypeEnum.STEELRIB" client="cl_Pset_ArchElementTypeSteelRib" supplier="cl_IfcArchElementTypeEnum_STEELRIB"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Qto_ArchElementBaseQuantities" name="Qto_ArchElementBaseQuantities">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Qto_ArchElementBaseQuantities_comment_0">
+        <body>QTO_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Qto_ArchElementBaseQuantities_CrossSectionArea" name="CrossSectionArea">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcAreaMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Qto_ArchElementBaseQuantities_CrossSectionArea_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Qto_ArchElementBaseQuantities_CrossSectionArea_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Qto_ArchElementBaseQuantities_InnerSurfaceArea" name="InnerSurfaceArea">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcAreaMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Qto_ArchElementBaseQuantities_InnerSurfaceArea_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Qto_ArchElementBaseQuantities_InnerSurfaceArea_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Qto_ArchElementBaseQuantities_Length" name="Length">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Qto_ArchElementBaseQuantities_Length_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Qto_ArchElementBaseQuantities_Length_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Qto_ArchElementBaseQuantities_OuterSurfaceArea" name="OuterSurfaceArea">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcAreaMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Qto_ArchElementBaseQuantities_OuterSurfaceArea_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Qto_ArchElementBaseQuantities_OuterSurfaceArea_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Qto_ArchElementBaseQuantities_Volume" name="Volume">
+        <type xmi:type="uml:Class" href="IfcQuantityResource.uml#cl_IfcQuantityVolume"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Qto_ArchElementBaseQuantities_Volume_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Qto_ArchElementBaseQuantities_Volume_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_ArchElementBaseQuantities_IfcArchElement" client="cl_Qto_ArchElementBaseQuantities" supplier="cl_IfcArchElement"/>
   </packagedElement>
 </uml:Model>


### PR DESCRIPTION
Editorial overlay on tunnel-team content (PR A):
- Pset_ArchElementCommon: IsLoadBearing -> LoadBearing per (PSET_REVIEW).csv
- PEnum_SegmentJointType: tail -> OTHER/NOTKNOWN/UNSET per 2_penum_update_applied.csv
- PEnum_BoltType: 2 literal renames (naming convention) + tail -> OTHER/NOTKNOWN/UNSET
