### PR TITLE
[TM20] Observations

### DIFF
--- a/docs/properties/a/AreaID.md
+++ b/docs/properties/a/AreaID.md
@@ -1,0 +1,5 @@
+AreaID
+======
+
+Identification of the single, specific mapped feature in the same mapped zone.
+>NOTE Mapped zone is represented in IFC using _IfcSpatialZone_ with PredefinedType _MAPPEDZONE_.

--- a/docs/properties/a/AzimuthHingeLine.md
+++ b/docs/properties/a/AzimuthHingeLine.md
@@ -1,0 +1,4 @@
+AzimuthHingeLine
+================
+
+The azimuth of the hinge line of the fold. The azimuth is given in degrees in the range 0 to 360 degrees counted clockwise from true north and expressed as a three-digit number, e.g. 240 or 015.

--- a/docs/properties/a/AzimuthHingeLineation.md
+++ b/docs/properties/a/AzimuthHingeLineation.md
@@ -1,0 +1,4 @@
+AzimuthHingeLineation
+=====================
+
+The azimuth of the lineation. The azimuth is given in degrees in the range 0 to 360 degrees counted clockwise from true north and expressed as a three-digit number, e.g. 240 or 015.

--- a/docs/properties/b/BoreholeDiameter.md
+++ b/docs/properties/b/BoreholeDiameter.md
@@ -1,0 +1,4 @@
+BoreholeDiameter
+================
+
+Drilled Borehole diameter. Also referred to as "Caliper", continuous measurement of the as-drilled diameter inside the borehole.

--- a/docs/properties/b/BoreholeGeophysConfiguration.md
+++ b/docs/properties/b/BoreholeGeophysConfiguration.md
@@ -1,0 +1,4 @@
+BoreholeGeophysConfiguration
+============================
+
+Configuration of the sources and receivers used in the borehole geophysical surveys.

--- a/docs/properties/b/Boulders.md
+++ b/docs/properties/b/Boulders.md
@@ -1,0 +1,4 @@
+Boulders
+========
+
+Description of expected or observed boulders features.

--- a/docs/properties/c/CPTConeResistance.md
+++ b/docs/properties/c/CPTConeResistance.md
@@ -1,0 +1,4 @@
+CPTConeResistance
+=================
+
+Cone penetration resistance measured during the CPT test.

--- a/docs/properties/c/CPTLocalSideFriction.md
+++ b/docs/properties/c/CPTLocalSideFriction.md
@@ -1,0 +1,4 @@
+CPTLocalSideFriction
+====================
+
+Sleeve friction measured during the test.

--- a/docs/properties/c/CPTPorePressure.md
+++ b/docs/properties/c/CPTPorePressure.md
@@ -1,0 +1,4 @@
+CPTPorePressure
+===============
+
+Pore pressure measured during the test.

--- a/docs/properties/c/CoveragePercentage.md
+++ b/docs/properties/c/CoveragePercentage.md
@@ -1,0 +1,4 @@
+CoveragePercentage
+==================
+
+Coverage in percentage of the mapped feature in relation to the mapped zone, e.g. tunnel face, to which it belongs.

--- a/docs/properties/c/Cracking.md
+++ b/docs/properties/c/Cracking.md
@@ -1,0 +1,4 @@
+Cracking
+========
+
+Qualitative crack values estimated from drilling information.

--- a/docs/properties/d/DefiningElement.md
+++ b/docs/properties/d/DefiningElement.md
@@ -1,0 +1,4 @@
+DefiningElement
+===============
+
+Kinds of describable inhomogeneity in a rock body that may define a geologic structure. Examples include oriented particle.

--- a/docs/properties/d/DeformationPhase.md
+++ b/docs/properties/d/DeformationPhase.md
@@ -1,0 +1,4 @@
+DeformationPhase
+================
+
+Name or label for a geologic event such as a basin formation, compressional tectonic phase, orogeny etc.

--- a/docs/properties/d/DepthRange.md
+++ b/docs/properties/d/DepthRange.md
@@ -1,0 +1,4 @@
+DepthRange
+==========
+
+Upper and bottom depth for certain geological information.

--- a/docs/properties/d/DipAngle.md
+++ b/docs/properties/d/DipAngle.md
@@ -1,0 +1,5 @@
+DipAngle
+========
+
+The maximum declination (dip) of the mean plane of the discontinuity from the horizontal shall be measured with the clinometer in the range 0 to 90 degrees and should be expressed in degrees as a two-digit number, e.g. 50.
+>NOTE Definition according to ISO EN 14689.

--- a/docs/properties/d/DipDirection.md
+++ b/docs/properties/d/DipDirection.md
@@ -1,0 +1,5 @@
+DipDirection
+============
+
+The azimuth of the dip (dip direction) shall be measured in degrees in the range 0 to 360 degrees counted clockwise from true north.
+>NOTE Definition according to ISO EN 14689.

--- a/docs/properties/d/DiscontinuityAperture.md
+++ b/docs/properties/d/DiscontinuityAperture.md
@@ -1,0 +1,5 @@
+DiscontinuityAperture
+=====================
+
+The perpendicular distance between the two surfaces of a discontinuity is referred to as the aperture.
+>NOTE Definition according to ISO EN 14689.

--- a/docs/properties/d/DiscontinuityCohesion.md
+++ b/docs/properties/d/DiscontinuityCohesion.md
@@ -1,0 +1,4 @@
+DiscontinuityCohesion
+=====================
+
+Cohesive shear strength of a rock or soil that is independent of interparticle friction.

--- a/docs/properties/d/DiscontinuityFrictionAngle.md
+++ b/docs/properties/d/DiscontinuityFrictionAngle.md
@@ -1,0 +1,4 @@
+DiscontinuityFrictionAngle
+==========================
+
+Derived from the Mohr-Coulomb failure criterion and used to describe the friction shear resistance of ground materials, together with the normal effective stress.

--- a/docs/properties/d/DiscontinuityInFilling.md
+++ b/docs/properties/d/DiscontinuityInFilling.md
@@ -1,0 +1,5 @@
+DiscontinuityInFilling
+======================
+
+The infilling material between discontinuity surfaces shall be identified and described (e.g. soil,minerals such as calcite, quartz, epidote, chlorite, anhydrite, clay gouge, rock gouge or breccia).
+>NOTE&nbsp;Definition according to ISO EN 14689.

--- a/docs/properties/d/DiscontinuityPersistence.md
+++ b/docs/properties/d/DiscontinuityPersistence.md
@@ -1,0 +1,5 @@
+DiscontinuityPersistence
+========================
+
+The linear extent of discontinuities from their inception to their termination in solid rock mass or against other discontinuities or outside the exposure shall be reported. The size of the exposure shall also be recorded. If possible and appropriate, measurements should be made in two or preferably three orthogonal directions.
+>NOTEDefinition according to ISO EN 14689.

--- a/docs/properties/d/DiscontinuityRoughness.md
+++ b/docs/properties/d/DiscontinuityRoughness.md
@@ -1,0 +1,9 @@
+DiscontinuityRoughness
+======================
+
+The surface condition and the shape of discontinuities shall be described on the basis of three scales of observation, respectively, and using the terms given in ISO EN 14689 - Table 9 and illustrated in Figure 2:
+a) small scale (several millimetres) - smooth or rough
+b) medium scale (several centimetres) - planar, stepped or undulating
+c) large scale (several metres) - straight, curved or wavy.
+
+>NOTEDefinition according to ISO EN 14689.

--- a/docs/properties/d/DiscontinuitySpacing.md
+++ b/docs/properties/d/DiscontinuitySpacing.md
@@ -1,0 +1,5 @@
+DiscontinuitySpacing
+====================
+
+The term "spacing" refers to the mean or modal spacing of a set of discontinuities and is the perpendicular distance between adjacent discontinuities. The discontinuity spacing should be measured in millimetres.
+>NOTE Definition from ISO 14689:2017, Table 8.

--- a/docs/properties/d/DiscontinuityType.md
+++ b/docs/properties/d/DiscontinuityType.md
@@ -1,0 +1,5 @@
+DiscontinuityType
+=================
+
+Pattern of bedding, folds, faults and discontinuities in rock masses, which subdivide the mass into individual domains or rock blocks.
+>NOTE&nbsp; Definition according to ISO EN 14689.

--- a/docs/properties/d/DiscontinuityWaterSeepage.md
+++ b/docs/properties/d/DiscontinuityWaterSeepage.md
@@ -1,0 +1,4 @@
+DiscontinuityWaterSeepage
+=========================
+
+Free moisture or water flow visible at individual spots or from discontinuities.

--- a/docs/properties/d/DryBulkDensity.md
+++ b/docs/properties/d/DryBulkDensity.md
@@ -1,0 +1,4 @@
+DryBulkDensity
+==============
+
+Ratio of the mass of the solid to the unit total volume (dry material).

--- a/docs/properties/f/FaultLength.md
+++ b/docs/properties/f/FaultLength.md
@@ -1,0 +1,4 @@
+FaultLength
+===========
+
+The longest horizontal or subhorizontal dimension along the fault plane.

--- a/docs/properties/f/FaultPitchAngle.md
+++ b/docs/properties/f/FaultPitchAngle.md
@@ -1,0 +1,6 @@
+FaultPitchAngle
+===============
+
+Angle between the strike of the slip surface and the slip vector (striation).
+
+> NOTE&nbsp; In geology, "pitch" and "rake" are terms used to describe the orientation and inclination of geological features, such as folds and faults, with respect to a horizontal plane. Pitch refers to the angle of inclination of a geological feature from the horizontal plane, measured perpendicular to the strike of the feature. It is commonly expressed in degrees or as a ratio of vertical to horizontal distance. For example, if a geological feature has a pitch of 45 degrees, it means that it is inclined at an angle of 45 degrees from the horizontal. Rake, on the other hand, refers to the angle of inclination of a geological feature measured parallel to the strike of the feature. It is also commonly expressed in degrees or as a ratio of vertical to horizontal distance. Rake is often used to describe the orientation of faults, where it represents the angle between the fault plane and a horizontal plane. Both pitch and rake are important parameters in geology as they can provide information about the deformation history and the mechanical behavior of rocks in response to tectonic forces.

--- a/docs/properties/f/FaultSlipDirection.md
+++ b/docs/properties/f/FaultSlipDirection.md
@@ -1,0 +1,4 @@
+FaultSlipDirection
+==================
+
+Observed relative displacement direction of the hanging wall (top) to the foot wall, e.g. up, down, left, right or combinations (like top down - left).

--- a/docs/properties/f/FaultThickness.md
+++ b/docs/properties/f/FaultThickness.md
@@ -1,0 +1,4 @@
+FaultThickness
+==============
+
+Thickness range of the fault zone, which can range from millimeters to kilometers.

--- a/docs/properties/f/FaultType.md
+++ b/docs/properties/f/FaultType.md
@@ -1,0 +1,4 @@
+FaultType
+=========
+
+Type of the fault classified with the dip and the direction of slip.

--- a/docs/properties/f/FoldType.md
+++ b/docs/properties/f/FoldType.md
@@ -1,0 +1,4 @@
+FoldType
+========
+
+Types of Geological Folds, which can be classified according to various factors independently.

--- a/docs/properties/f/FractureIndex.md
+++ b/docs/properties/f/FractureIndex.md
@@ -1,0 +1,4 @@
+FractureIndex
+=============
+
+Count of the number or spacing of fractures over an arbitrary length of core.

--- a/docs/properties/g/GSI.md
+++ b/docs/properties/g/GSI.md
@@ -1,0 +1,5 @@
+GSI
+===
+
+The Geological Strength Index (GSI): A characterization tool for assessing engineering properties for rock masses.
+>NOTE Definition from Marinos & Hoek (2000) GSI: A Geologically Friendly Tool For Rock Mass Strength Estimation. [Link](https://static.rocscience.cloud/assets/resources/learning/hoek/2000-GSI-A-Geologically-Friendly-Tool-for-Rock-Mass-Strength-Estimation.pdf).

--- a/docs/properties/g/GammaRay.md
+++ b/docs/properties/g/GammaRay.md
@@ -1,0 +1,4 @@
+GammaRay
+========
+
+Naturally occurring gamma radiation which characterizes the rock or sediment in a borehole or drill hole, measured by a gamma ray logging.

--- a/docs/properties/g/GasConcentration.md
+++ b/docs/properties/g/GasConcentration.md
@@ -1,0 +1,4 @@
+GasConcentration
+================
+
+Expected concentration of gas to be encountered during excavation.

--- a/docs/properties/g/GeologicalStrengthIndex.md
+++ b/docs/properties/g/GeologicalStrengthIndex.md
@@ -1,5 +1,5 @@
-GSI
-===
+GeologicalStrengthIndex
+=======================
 
 The Geological Strength Index (GSI): A characterization tool for assessing engineering properties for rock masses.
 >NOTE Definition from Marinos & Hoek (2000) GSI: A Geologically Friendly Tool For Rock Mass Strength Estimation. [Link](https://static.rocscience.cloud/assets/resources/learning/hoek/2000-GSI-A-Geologically-Friendly-Tool-for-Rock-Mass-Strength-Estimation.pdf).

--- a/docs/properties/g/GeologyCode.md
+++ b/docs/properties/g/GeologyCode.md
@@ -1,0 +1,4 @@
+GeologyCode
+===========
+
+Reference to any existing classification, e.g. from ageological survey or stratigraphy table.

--- a/docs/properties/g/GroundTemperature.md
+++ b/docs/properties/g/GroundTemperature.md
@@ -1,0 +1,4 @@
+GroundTemperature
+=================
+
+Ground temperature expected in the subject section.

--- a/docs/properties/g/GroundwaterAgressiveness.md
+++ b/docs/properties/g/GroundwaterAgressiveness.md
@@ -1,0 +1,4 @@
+GroundwaterAgressiveness
+========================
+
+Rating of the agressiveness e.g. towards concrete.

--- a/docs/properties/g/GroundwaterTemperature.md
+++ b/docs/properties/g/GroundwaterTemperature.md
@@ -1,0 +1,4 @@
+GroundwaterTemperature
+======================
+
+Groundwater temperature observed at specific location or expected in the subject section.

--- a/docs/properties/h/HydraulicPermeability.md
+++ b/docs/properties/h/HydraulicPermeability.md
@@ -1,0 +1,4 @@
+HydraulicPermeability
+=====================
+
+A measurement of the ability of a fluid to flow through a rock. Represented by the variable "k". The quality of the soil that enables water to move through the profile. Permeability is measured as the number of metres per sec that water moves through the saturated soil.

--- a/docs/properties/i/InflowRate.md
+++ b/docs/properties/i/InflowRate.md
@@ -1,0 +1,4 @@
+InflowRate
+==========
+
+Measured or expected water inflow rate during observation.

--- a/docs/properties/i/InflowSum.md
+++ b/docs/properties/i/InflowSum.md
@@ -1,0 +1,4 @@
+InflowSum
+=========
+
+Groundwater inflow measured or expected during one hour.

--- a/docs/properties/i/IsPiezometric.md
+++ b/docs/properties/i/IsPiezometric.md
@@ -1,0 +1,4 @@
+IsPiezometric
+=============
+
+Defines whether height measurements are made vs the piezometric surface (true) or the surface of the groundwater (false).

--- a/docs/properties/k/Karst.md
+++ b/docs/properties/k/Karst.md
@@ -1,0 +1,4 @@
+Karst
+=====
+
+Description of expected or observed karst features.

--- a/docs/properties/l/LineationType.md
+++ b/docs/properties/l/LineationType.md
@@ -1,0 +1,4 @@
+LineationType
+=============
+
+Flow lines, scratches, striae, slickenlines, linear arrangements of elongate components in sediments, elongate minerals, crinkles, and lines of intersection between penetrative planar structures.

--- a/docs/properties/l/LiquidLimits.md
+++ b/docs/properties/l/LiquidLimits.md
@@ -1,0 +1,5 @@
+LiquidLimits
+============
+
+The water content in percent where the soil starts to behave as a liquid.
+> NOTE&nbsp; Definition according to ISO17892.

--- a/docs/properties/l/Lithology.md
+++ b/docs/properties/l/Lithology.md
@@ -1,0 +1,4 @@
+Lithology
+=========
+
+Defines all natural materials resulting from the combination of minerals, particles or biogenic elements.

--- a/docs/properties/l/LugeonValue.md
+++ b/docs/properties/l/LugeonValue.md
@@ -1,0 +1,4 @@
+LugeonValue
+===========
+
+Lugeon Value = (q / L) x (P0 / P), where: q - flow rate [lit/min], L - Length of the borehole test interval [m], P0 - reference pressure of 1 MPa [MPa], P - Test pressure [MPa].

--- a/docs/properties/m/MenardLimitPressure.md
+++ b/docs/properties/m/MenardLimitPressure.md
@@ -1,0 +1,4 @@
+MenardLimitPressure
+===================
+
+The limit pressure, resulting from interpretation of Menard's pressuremeter test.

--- a/docs/properties/m/MenardLoadingUnloadingRatio.md
+++ b/docs/properties/m/MenardLoadingUnloadingRatio.md
@@ -1,0 +1,4 @@
+MenardLoadingUnloadingRatio
+===========================
+
+The reloading modulus, resulting from the interpretation of Menard's pressuremeter test.

--- a/docs/properties/m/MenardPressuremeterModulus.md
+++ b/docs/properties/m/MenardPressuremeterModulus.md
@@ -1,0 +1,4 @@
+MenardPressuremeterModulus
+==========================
+
+The first loading modulus, resulting from the interpretation of Menard's pressuremeter test.

--- a/docs/properties/o/ObservationEndDate.md
+++ b/docs/properties/o/ObservationEndDate.md
@@ -1,0 +1,4 @@
+ObservationEndDate
+==================
+
+End date when the observation was made.

--- a/docs/properties/o/ObservationStartDate.md
+++ b/docs/properties/o/ObservationStartDate.md
@@ -1,0 +1,4 @@
+ObservationStartDate
+====================
+
+Start date when the observation was made.

--- a/docs/properties/p/PlasticLimit.md
+++ b/docs/properties/p/PlasticLimit.md
@@ -1,0 +1,5 @@
+PlasticLimit
+============
+
+The water content in percent where the soil starts  to behave as a semi-solid state.
+> NOTE&nbsp; Definition according to ISO17892.

--- a/docs/properties/p/PlasticityIndex.md
+++ b/docs/properties/p/PlasticityIndex.md
@@ -1,0 +1,4 @@
+PlasticityIndex
+===============
+
+The plasticity index Ip is the numerical difference between the liquid limit and plastic limit of a fine soil.IP = wL - wP.

--- a/docs/properties/p/Plunge.md
+++ b/docs/properties/p/Plunge.md
@@ -1,0 +1,4 @@
+Plunge
+======
+
+The angle of inclination of the fold axis with the horizontal as measured in a vertical plane.

--- a/docs/properties/p/PressuremeterType.md
+++ b/docs/properties/p/PressuremeterType.md
@@ -1,0 +1,4 @@
+PressuremeterType
+=================
+
+Indication of the type of equipment used for the pressuremeter test.

--- a/docs/properties/q/QValue.md
+++ b/docs/properties/q/QValue.md
@@ -1,0 +1,15 @@
+QValue
+======
+
+A description of the rock mass stability of an underground opening in jointed rock masses.
+
+>NOTE Definition from Barton, N.R.; Lien, R.; Lunde, J. (1974). Engineering classification of rock masses for the design of tunnel support. Rock Mechanics and Rock Engineering.
+
+Use of the Q-system is specifically recommended for tunnels and caverns with an arched roof.
+The Q-value is determined with:
+$$
+Q = \frac{RQD}{Jn}*\frac{Jr}{Ja}*\frac{Jw}{SRF}
+$$
+where RQD (Rock Quality Designation) divided by Jn (joint set number) is related to the size of the intact rock blocks in the rock mass. The second term Jr (joint roughness number) divided by Ja (joint alteration number) is related to the shear strength along the discontinuity planes and the third term Jw (joint water parameter) divided by SRF (stress reduction factor) is related to the stress environment on the intact rock blocks and discontinuities around the underground excavation.
+
+A multiplication of the three terms results in the Q parameter, which can range between 0.001 for an exceptionally poor to 1000 for an exceptionally good rock mass. The numerical values of the class boundaries for the different rock mass qualities are subdivisions of the Q range on a logarithmic scale.

--- a/docs/properties/r/RMR.md
+++ b/docs/properties/r/RMR.md
@@ -1,0 +1,6 @@
+RMR
+===
+
+The rock mass rating (RMR) is a geomechanical classification system for rocks.
+>NOTE Definition from ASTM (1988). Standard Guide for using the Rock Mass Rating (RMR) System (Geomechanics Classification) in Engineering Practices. American Society for Testing and Materials, Book of Standards D5878-08, v.04.09, Philadelphia, PA.
+>NOTE Developed by Z. T. Bieniawski.

--- a/docs/properties/r/RockMassRating.md
+++ b/docs/properties/r/RockMassRating.md
@@ -1,5 +1,5 @@
-RMR
-===
+RockMassRating
+==============
 
 The rock mass rating (RMR) is a geomechanical classification system for rocks.
 >NOTE Definition from ASTM (1988). Standard Guide for using the Rock Mass Rating (RMR) System (Geomechanics Classification) in Engineering Practices. American Society for Testing and Materials, Book of Standards D5878-08, v.04.09, Philadelphia, PA.

--- a/docs/properties/r/RockQualityDesignation.md
+++ b/docs/properties/r/RockQualityDesignation.md
@@ -1,0 +1,4 @@
+RockQualityDesignation
+======================
+
+Quotient of the cumulative length of drill cores with a length greater than 10 cm, by the total length of the drill core pass with a length greater than or equal to 1m.

--- a/docs/properties/s/SampleBoreholeDepthRange.md
+++ b/docs/properties/s/SampleBoreholeDepthRange.md
@@ -1,0 +1,4 @@
+SampleBoreholeDepthRange
+========================
+
+Relative top and bottom depths of a borehole where a sample was retrieved.

--- a/docs/properties/s/SampleProcedure.md
+++ b/docs/properties/s/SampleProcedure.md
@@ -1,0 +1,4 @@
+SampleProcedure
+===============
+
+Description of steps performed by a Sampler in order to extract a Sample from its sampledFeature in the frame of a Sampling.

--- a/docs/properties/s/SamplePurpose.md
+++ b/docs/properties/s/SamplePurpose.md
@@ -1,0 +1,4 @@
+SamplePurpose
+=============
+
+Provides the reason why the sample was collected, planed methods for testingand analysis.

--- a/docs/properties/s/SampleType.md
+++ b/docs/properties/s/SampleType.md
@@ -1,0 +1,4 @@
+SampleType
+==========
+
+Type of a sample with respect to sampling method and material, with e.g. enumerations as defined in AGS.

--- a/docs/properties/s/SamplingPointType.md
+++ b/docs/properties/s/SamplingPointType.md
@@ -1,0 +1,4 @@
+SamplingPointType
+=================
+
+Specifies the location from where the material sample was obtained, e.g. outcrop point, tunnel chainage, any other local reference.

--- a/docs/properties/s/Slaking.md
+++ b/docs/properties/s/Slaking.md
@@ -1,0 +1,4 @@
+Slaking
+=======
+
+The crumbling and disintegration of rock or hard soil upon exposure to air or water.

--- a/docs/properties/s/SolidCoreRecovery.md
+++ b/docs/properties/s/SolidCoreRecovery.md
@@ -1,0 +1,4 @@
+SolidCoreRecovery
+=================
+
+Length of solid core recovered expressed as a ratio of the length of core run.

--- a/docs/properties/s/SourceArea.md
+++ b/docs/properties/s/SourceArea.md
@@ -1,0 +1,4 @@
+SourceArea
+==========
+
+Description of the area at the origin of the water inflow.

--- a/docs/properties/s/SourceType.md
+++ b/docs/properties/s/SourceType.md
@@ -1,0 +1,4 @@
+SourceType
+==========
+
+Natural or artificial structure at the origin of the water inflow, like fracture, bedding, borehole, drainage pipe, drainage channel etc.

--- a/docs/properties/s/SpontaneousPotential.md
+++ b/docs/properties/s/SpontaneousPotential.md
@@ -1,0 +1,4 @@
+SpontaneousPotential
+====================
+
+Naturally occurring (static) electrical potential in the Earth. Spontaneous potentials (SP) are usually caused by charge separation in clay or other minerals, by the presence of a semipermeable interface impeding the diffusion of ions through the pore space of rocks, or by natural flow of a conducting fluid (salty water) through the rocks. Variations in SP can be measured in the field and in wellbores to determine variations of ionic concentration in pore fluids of rocks.

--- a/docs/properties/s/Storativity.md
+++ b/docs/properties/s/Storativity.md
@@ -1,0 +1,4 @@
+Storativity
+===========
+
+Volume of water released from storage per unit surface area of a confined aquifer per unit decline in hydraulic head. It is dimensionless.

--- a/docs/properties/s/SurveyDimension.md
+++ b/docs/properties/s/SurveyDimension.md
@@ -1,0 +1,4 @@
+SurveyDimension
+===============
+
+Dimension of the geophysical survey.

--- a/docs/properties/s/SurveyInstrumentManufacturer.md
+++ b/docs/properties/s/SurveyInstrumentManufacturer.md
@@ -1,0 +1,4 @@
+SurveyInstrumentManufacturer
+============================
+
+Manufacturer of the instrument used in the geophysical survey.

--- a/docs/properties/s/SurveyInstrumentModel.md
+++ b/docs/properties/s/SurveyInstrumentModel.md
@@ -1,0 +1,4 @@
+SurveyInstrumentModel
+=====================
+
+Model/name of the instrument used in the geophysical survey.

--- a/docs/properties/s/SurveyMethod.md
+++ b/docs/properties/s/SurveyMethod.md
@@ -1,0 +1,4 @@
+SurveyMethod
+============
+
+Method of gephysical survey used.

--- a/docs/properties/t/TestDepthRange.md
+++ b/docs/properties/t/TestDepthRange.md
@@ -1,0 +1,4 @@
+TestDepthRange
+==============
+
+The depth range where the test was performed.

--- a/docs/properties/t/TestMethod.md
+++ b/docs/properties/t/TestMethod.md
@@ -1,0 +1,4 @@
+TestMethod
+==========
+
+Name of the test method that was used to optain the exchanged results.

--- a/docs/properties/t/TestStandard.md
+++ b/docs/properties/t/TestStandard.md
@@ -1,0 +1,4 @@
+TestStandard
+============
+
+Reference to standard that describes the test merthodology.

--- a/docs/properties/t/TestType.md
+++ b/docs/properties/t/TestType.md
@@ -1,0 +1,4 @@
+TestType
+========
+
+The test type.

--- a/docs/properties/t/TestedMaterial.md
+++ b/docs/properties/t/TestedMaterial.md
@@ -1,0 +1,4 @@
+TestedMaterial
+==============
+
+Description of the tested material, e.g. according to existing rock and soil classification systems.

--- a/docs/properties/t/TotalCoreRecovery.md
+++ b/docs/properties/t/TotalCoreRecovery.md
@@ -1,0 +1,4 @@
+TotalCoreRecovery
+=================
+
+Length of core recovered (solid and non-intact) expressed as a ratio of the length of core run.

--- a/docs/properties/t/Transmissivity.md
+++ b/docs/properties/t/Transmissivity.md
@@ -1,0 +1,4 @@
+Transmissivity
+==============
+
+Rate of flow of groundwater under a unit hydraulic gradient through an aquifer of unit width and unit thickness. That is, transmissivity is the product of hydraulic conductivity and thickness of the aquifer. The unit is in m2/second.

--- a/docs/properties/u/UnconfinedCompressiveStrength.md
+++ b/docs/properties/u/UnconfinedCompressiveStrength.md
@@ -1,0 +1,4 @@
+UnconfinedCompressiveStrength
+=============================
+
+The unconfined compressive strength (UCS) is the maximum axial compressive stress that a right-cylindrical sample of material can withstand under unconfined conditions.

--- a/docs/properties/v/Veining.md
+++ b/docs/properties/v/Veining.md
@@ -1,0 +1,4 @@
+Veining
+=======
+
+Description of observed vein structures related to hydrothermal alteration, mineralisation etc.

--- a/docs/properties/w/WaterLeakage.md
+++ b/docs/properties/w/WaterLeakage.md
@@ -1,0 +1,4 @@
+WaterLeakage
+============
+
+Degree of water leakage estimated from water flow information.

--- a/docs/properties/w/WaterLevel.md
+++ b/docs/properties/w/WaterLevel.md
@@ -1,0 +1,4 @@
+WaterLevel
+==========
+
+Measured distance to water level in borehole from ground surface.

--- a/docs/properties/w/Weathering.md
+++ b/docs/properties/w/Weathering.md
@@ -1,0 +1,5 @@
+Weathering
+==========
+
+Description of the physical and chemical changes produced by atmospheric agents in rocks or other deposits at or near the earth's surface. These changes result in disintegration and decomposition of the material.
+> NOTE Definition according to ISO 14689:2017.

--- a/docs/properties/w/WetBulkDensity.md
+++ b/docs/properties/w/WetBulkDensity.md
@@ -1,0 +1,4 @@
+WetBulkDensity
+==============
+
+Ratio of the total mass to the unit total volume (material at its natural moisture content).

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcComplementaryData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcComplementaryData.md
@@ -1,0 +1,5 @@
+# IfcComplementaryData
+
+A kind of product with the purpose of providing additional raw data, such as observations,  to other products. Complementary data may carry its own representation and shall be related to the main product using _IfcRelAssignsToProduct_.
+<!-- end of short definition -->
+

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcObservation.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcObservation.md
@@ -1,0 +1,5 @@
+# IfcObservation
+
+A generic representation of an observation that can be assigned to another product using _IfcRelAssignsToProduct_. Actual observation data should be assigned to instances of this entity or any sub-entity either by using pre- or user defined property sets or by assigning external datasets using _IfcRelAssociatesDataset_.
+<!-- end of short definition -->
+

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeoScienceObservation.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeoScienceObservation.md
@@ -1,0 +1,15 @@
+# IfcGeoScienceObservation
+
+Detailed collected information, including measured parameters, descriptions etc. related to geoscientific observations that can be assigned to physical or spatial elements using _IfcRelAssignsToProduct_.
+<!-- end of short definition -->
+
+## Attributes
+
+### PredefinedType
+Identifies the predefined type of a geoscience observation. This type may associate additional specific property sets.
+
+## Formal Propositions
+
+### HasObjectType
+The attribute ObjectType shall be given if the predefined type is set to USERDEFINED.
+

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_DiscontinuitySpacing.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_DiscontinuitySpacing.md
@@ -20,3 +20,12 @@ Less than 20 mm.
 
 ### VERY_WIDE
 Greater than 2000 mm.
+
+### OTHER
+The type is user-defined.
+
+### NOTKNOWN
+Value is unknown.
+
+### UNSET
+Value has not been specified.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_DiscontinuitySpacing.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_DiscontinuitySpacing.md
@@ -1,0 +1,22 @@
+# PEnum_DiscontinuitySpacing
+<!-- end of short definition -->
+
+## Items
+
+### EXTREMELY_CLOSE
+Less than 20 mm.
+
+### VERY_CLOSE
+20 to 60 mm.
+
+### CLOSE
+60 to 200 mm.
+
+### MEDIUM
+200-600 mm.
+
+### WIDE
+600 to 2000 mm.
+
+### VERY_WIDE
+Greater than 2000 mm.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GeophysicalSurveyMethod.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GeophysicalSurveyMethod.md
@@ -35,3 +35,12 @@ Measuring variations in the magnetic field of the earth which are related to cha
 
 ### NMR
 Measuring magnetic resonance signals from proton-containing fluids (e.g. water, hydrocarbons) in the earth's subsurface.
+
+### OTHER
+The type is user-defined.
+
+### NOTKNOWN
+Value is unknown.
+
+### UNSET
+Value has not been specified.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GeophysicalSurveyMethod.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_GeophysicalSurveyMethod.md
@@ -1,0 +1,37 @@
+# PEnum_GeophysicalSurveyMethod
+<!-- end of short definition -->
+
+## Items
+
+### REFLECTION_SEISMIC
+Using seismic waves reflected from the interface between formations having different physical properties to map geological structures and/or stratigraphic features.
+
+### REFRACTION_SEISMIC
+Using the refraction of seismic waves on geology layers and rock/soil units to characterize subsurface geologic conditions.
+
+### SURFACEWAVE_SEISMIC
+Using seismic waves that travel along (or near to) the surface to assess the surface wave velocity in the subsurface.
+
+### PASSIVE_SEISMIC
+Using listening capabilities only, that is, no seismic energy is added by the investigator.
+
+### OTHER_SEISMIC
+Any other type of seismic survey method.
+
+### ELECTRICAL
+Introducing current into the ground and measuring the distribution of the resulting potential in the ground to map electrical properties in the subsurface.
+
+### ELECTROMAGNETIC
+Detecting the electromagnetic properties of the subsurface by inducing low-frequency electromagnetic fields within the subsurface and measuring the response of earth's materials.
+
+### RADAR
+Using radar pulses to image the subsurface.
+
+### GRAVITY
+Measuring variations in the gravitational field of the earth to detect the density changes of subsurface bodies.
+
+### MAGNETIC
+Measuring variations in the magnetic field of the earth which are related to changes of structures or magnetic susceptibility in the subsurface.
+
+### NMR
+Measuring magnetic resonance signals from proton-containing fluids (e.g. water, hydrocarbons) in the earth's subsurface.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_Weathering.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_Weathering.md
@@ -1,0 +1,16 @@
+# PEnum_Weathering
+<!-- end of short definition -->
+
+## Items
+
+### FRESH
+No visible sign of weathering/alteration of the rock.
+
+### DISCOLOURED
+The colour of the original fresh rock is changed and is evidence of weathering/alteration. The degree of change from the original colour should be indicated. If the change is confined to particular mineral constituents, this should be mentioned.
+
+### DISINTEGRATED
+The rock is broken up by physical weathering, so that bonding between grains is lost and the rock is weathered/altered towards the condition of a soil in which the original material fabric is still intact. The rock material is friable but the mineral grains are not decomposed.
+
+### DECOMPOSED
+The rock is weathered by the chemical alteration of the mineral grains to the condition of a soil in which the original material fabric is still intact; some or all of the mineral grains are decomposed.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_Weathering.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertyEnumerations/PEnum_Weathering.md
@@ -14,3 +14,12 @@ The rock is broken up by physical weathering, so that bonding between grains is 
 
 ### DECOMPOSED
 The rock is weathered by the chemical alteration of the mineral grains to the condition of a soil in which the original material fabric is still intact; some or all of the mineral grains are decomposed.
+
+### OTHER
+The type is user-defined.
+
+### NOTKNOWN
+Value is unknown.
+
+### UNSET
+Value has not been specified.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_BoreholeTestPressuremeter.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_BoreholeTestPressuremeter.md
@@ -1,0 +1,4 @@
+# Pset_BoreholeTestPressuremeter
+
+Properties for results of pressuremeter tests in boreholes.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_BoreholeTestSPT.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_BoreholeTestSPT.md
@@ -1,0 +1,4 @@
+# Pset_BoreholeTestSPT
+
+Properties for results of Standard Penetration Tests/Standard Penetrometer Tests (SPTs).
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeCommon.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsBoreholeCommon
+
+Common properties for borehole logs.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeGeoLogInterval.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeGeoLogInterval.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsBoreholeGeoLogInterval
+
+Properties for geolog intervals.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeGeophysicalInterval.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeGeophysicalInterval.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsBoreholeGeophysicalInterval
+
+Properties for describing geophysical intervals.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeMWDInterval.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeMWDInterval.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsBoreholeMWDInterval
+
+Properties for describing MWD (Measure While Drilling) intervals.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeWaterLevel.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsBoreholeWaterLevel.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsBoreholeWaterLevel
+
+Properties for describing water levels in boreholes.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsCommon.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsCommon
+
+Common properties for geoscience observations.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsDiscontinuityCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsDiscontinuityCommon.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsDiscontinuityCommon
+
+Properties of discontinuities or discontinuity sets in rock according to ISO EN 14689.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsDiscontinuityFault.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsDiscontinuityFault.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsDiscontinuityFault
+
+Properties for geological fault observations.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsFoldAxis.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsFoldAxis.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsFoldAxis
+
+Properties for geological fold axis observations.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsHydroGeologyWaterInflow.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsHydroGeologyWaterInflow.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsHydroGeologyWaterInflow
+
+Properties for hydrogeological water inflow observations.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsLineation.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsLineation.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsLineation
+
+Properties for geological lineation observations.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsMappedUnit.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsMappedUnit.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsMappedUnit
+
+Properties for geoscience observations at mapped units.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsPtObservationCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeoObsPtObservationCommon.md
@@ -1,0 +1,4 @@
+# Pset_GeoObsPtObservationCommon
+
+Properties for geo-science observations at points.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeophysicalSurveyBorehole.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeophysicalSurveyBorehole.md
@@ -1,0 +1,4 @@
+# Pset_GeophysicalSurveyBorehole
+
+Properties for setup of geophysical surveys incorporating boreholes.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeophysicalSurveyCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_GeophysicalSurveyCommon.md
@@ -1,0 +1,4 @@
+# Pset_GeophysicalSurveyCommon
+
+Common properties for geophysical surveys.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCPT.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCPT.md
@@ -1,0 +1,4 @@
+# Pset_InSituTestCPT
+
+Properties for the results of Cone Penetration Tests/Cone Penetrometer Tests (CPTs).
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon.md
@@ -1,0 +1,4 @@
+# Pset_InSituTestCommon
+
+Properties in common for in-situ tests in soil or rock.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestHydro.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestHydro.md
@@ -1,0 +1,4 @@
+# Pset_InSituTestHydro
+
+Properties for the results of in-situ pumping tests in soil or rock.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_LabTestCommon.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_LabTestCommon.md
@@ -1,0 +1,4 @@
+# Pset_LabTestCommon
+
+Properties describing the laboratory test used to obtain the associated results.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_LabTestResult.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_LabTestResult.md
@@ -1,0 +1,4 @@
+# Pset_LabTestResult
+
+Properties resulting from commonly conducted laboratory tests on soil, rock or fluid specimens.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_SpatialGeoObsSample.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/PropertySets/Pset_SpatialGeoObsSample.md
@@ -1,0 +1,4 @@
+# Pset_SpatialGeoObsSample
+
+Common properties for samples.
+<!-- end of short definition -->

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Types/IfcGeoScienceObservationTypeEnum.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Types/IfcGeoScienceObservationTypeEnum.md
@@ -1,0 +1,31 @@
+# IfcGeoScienceObservationTypeEnum
+
+This enumeration defines the different predefined types of geoscience observation types that can specify an _IfcGeoScienceObservation_.
+<!-- end of short definition -->
+
+## Items
+
+### INSITUTESTRESULT
+Result from a test carried out on site directly in place, e.g. in a borehole, a gallery or from the surface.
+
+### LABTESTRESULT
+Result from test on a rock/soil (geologic) or fluid specimen carried out in a laboratory.
+
+### BOREHOLELOG
+Any kind of observation or measurement result related to intervals or points on the borehole axis.
+
+### MAPPEDFEATURE
+Distinctly mapped structures that have been observed on MappedZones such as lineations, fold axes, discontinuity surfaces etc.
+
+### LOCALINFORMATION
+Other observations made locally (e.g. at a point) such as discontinuities, water inflow, weathering, rockburst etc.
+
+### GEOPHYSICALSURVEYRESULT
+A systematic collection of geophysical data that was gathered either at or near the ground surface or by using boreholes and measuring the whole volume in between (crosshole).
+
+### USERDEFINED
+User-defined type.
+
+### NOTDEFINED
+Undefined type.
+

--- a/schemas/IfcProductExtension.uml
+++ b/schemas/IfcProductExtension.uml
@@ -256,11 +256,12 @@
         <specification xmi:type="uml:OpaqueExpression" xmi:id="cl_IfcRelAssociatesMaterial_AllowedElements" name="AllowedElements">
           <language>EXPRESS_WHERE</language>
           <body>SIZEOF(QUERY(temp &lt;* SELF\IfcRelAssociates.RelatedObjects | (
-  SIZEOF(TYPEOF(temp) * [   
-    'IFC4X3_ADD2.IFCELEMENT', 
+  SIZEOF(TYPEOF(temp) * [
+    'IFC4X3_ADD2.IFCELEMENT',
     'IFC4X3_ADD2.IFCELEMENTTYPE',
     'IFC4X3_ADD2.IFCSTRUCTURALMEMBER',
-    'IFC4X3_ADD2.IFCPORT']) = 0) 
+    'IFC4X3_ADD2.IFCPORT',
+    'IFC4X3_ADD2.IFCGEOSCIENCEOBSERVATION']) = 0)
 )) = 0</body>
         </specification>
       </ownedRule>
@@ -3843,5 +3844,13 @@ AND
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_ProjectionElementBaseQuantities_IfcProjectionElement" client="cl_Qto_ProjectionElementBaseQuantities" supplier="cl_IfcProjectionElement"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_SiteBaseQuantities_IfcSite" client="cl_Qto_SiteBaseQuantities" supplier="cl_IfcSite"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_SpaceBaseQuantities_IfcSpace" client="cl_Qto_SpaceBaseQuantities" supplier="cl_IfcSpace"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcComplementaryData" name="IfcComplementaryData" isAbstract="true">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcComplementaryData_gen_IfcProduct">
+        <general xmi:type="uml:Class" href="IfcKernel.uml#cl_IfcProduct"/>
+      </generalization>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcObservation" name="IfcObservation">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcObservation_gen_IfcComplementaryData" general="cl_IfcComplementaryData"/>
+    </packagedElement>
   </packagedElement>
 </uml:Model>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1764,6 +1764,9 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_MEDIUM" name="MEDIUM"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_WIDE" name="WIDE"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_VERY_WIDE" name="VERY_WIDE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_Weathering" name="PEnum_Weathering">
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_FRESH" name="FRESH"/>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1271,5 +1271,808 @@
       <supplier xmi:type="uml:Class" href="IfcStructuralElementsDomain.uml#cl_IfcSurfaceFeature"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_VolumetricStratumBaseQuantities_IfcGeotechnicalStratum" client="cl_Qto_VolumetricStratumBaseQuantities" supplier="cl_IfcGeotechnicalStratum"/>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_IfcGeoScienceObservationTypeEnum" name="IfcGeoScienceObservationTypeEnum">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" name="INSITUTESTRESULT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_LABTESTRESULT" name="LABTESTRESULT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_BOREHOLELOG" name="BOREHOLELOG"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" name="MAPPEDFEATURE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION" name="LOCALINFORMATION"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT" name="GEOPHYSICALSURVEYRESULT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_USERDEFINED" name="USERDEFINED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcGeoScienceObservationTypeEnum_NOTDEFINED" name="NOTDEFINED"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservation" name="IfcGeoScienceObservation">
+      <ownedRule xmi:type="uml:Constraint" xmi:id="ct_IfcGeoScienceObservation_HasObjectType" name="HasObjectType">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="cl_IfcGeoScienceObservation_HasObjectType" name="HasObjectType">
+          <language>EXPRESS_WHERE</language>
+          <body>(PredefinedType &lt;> IfcGeoScienceObservationTypeEnum.USERDEFINED) OR EXISTS(SELF\IfcObject.ObjectType)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservation_gen_IfcObservation">
+        <general xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcObservation"/>
+      </generalization>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcGeoScienceObservation_PredefinedType" name="PredefinedType" type="en_IfcGeoScienceObservationTypeEnum">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcGeoScienceObservation_PredefinedType_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcGeoScienceObservation_PredefinedType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" name="IfcGeoScienceObservationTypeEnum.INSITUTESTRESULT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_LABTESTRESULT" name="IfcGeoScienceObservationTypeEnum.LABTESTRESULT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_LABTESTRESULT_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_BOREHOLELOG" name="IfcGeoScienceObservationTypeEnum.BOREHOLELOG">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_BOREHOLELOG_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" name="IfcGeoScienceObservationTypeEnum.MAPPEDFEATURE">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION" name="IfcGeoScienceObservationTypeEnum.LOCALINFORMATION">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT" name="IfcGeoScienceObservationTypeEnum.GEOPHYSICALSURVEYRESULT">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_USERDEFINED" name="IfcGeoScienceObservationTypeEnum.USERDEFINED">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_USERDEFINED_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoScienceObservationTypeEnum_NOTDEFINED" name="IfcGeoScienceObservationTypeEnum.NOTDEFINED">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoScienceObservationTypeEnum_NOTDEFINED_gen_IfcGeoScienceObservation" general="cl_IfcGeoScienceObservation"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_BoreholeTestPressuremeter" name="Pset_BoreholeTestPressuremeter">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_BoreholeTestPressuremeter_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardLimitPressure" name="MenardLimitPressure">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardLimitPressure_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardLimitPressure_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardLoadingUnloadingRatio" name="MenardLoadingUnloadingRatio">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardLoadingUnloadingRatio_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardLoadingUnloadingRatio_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardPressuremeterModulus" name="MenardPressuremeterModulus">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardPressuremeterModulus_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_BoreholeTestPressuremeter_MenardPressuremeterModulus_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_BoreholeTestPressuremeter_PressuremeterType" name="PressuremeterType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_BoreholeTestPressuremeter_PressuremeterType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_BoreholeTestPressuremeter_PressuremeterType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_BoreholeTestPressuremeter_YoungModulus" name="YoungModulus">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcModulusOfElasticityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_BoreholeTestPressuremeter_YoungModulus_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_BoreholeTestPressuremeter_YoungModulus_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_BoreholeTestPressuremeter_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" client="cl_Pset_BoreholeTestPressuremeter" supplier="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_BoreholeTestSPT" name="Pset_BoreholeTestSPT">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_BoreholeTestSPT_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_BoreholeTestSPT_YoungModulus" name="YoungModulus">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcModulusOfElasticityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_BoreholeTestSPT_YoungModulus_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_BoreholeTestSPT_YoungModulus_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_BoreholeTestSPT_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" client="cl_Pset_BoreholeTestSPT" supplier="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsBoreholeCommon" name="Pset_GeoObsBoreholeCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsBoreholeCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeCommon_DepthRange" name="DepthRange">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcNonNegativeLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeCommon_DepthRange_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeCommon_DepthRange_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsBoreholeCommon_IfcGeoScienceObservationTypeEnum_BOREHOLELOG" client="cl_Pset_GeoObsBoreholeCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_BOREHOLELOG"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsBoreholeGeoLogInterval" name="Pset_GeoObsBoreholeGeoLogInterval">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsBoreholeGeoLogInterval_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_FractureIndex" name="FractureIndex">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcCountMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_FractureIndex_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_FractureIndex_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_GeologyCode" name="GeologyCode">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_GeologyCode_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_GeologyCode_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_RockQualityDesignation" name="RockQualityDesignation">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_RockQualityDesignation_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_RockQualityDesignation_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_SolidCoreRecovery" name="SolidCoreRecovery">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_SolidCoreRecovery_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_SolidCoreRecovery_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_TotalCoreRecovery" name="TotalCoreRecovery">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_TotalCoreRecovery_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_TotalCoreRecovery_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_Weathering" name="Weathering">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_Weathering_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeoLogInterval_Weathering_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsBoreholeGeoLogInterval_IfcGeoScienceObservationTypeEnum_BOREHOLELOG" client="cl_Pset_GeoObsBoreholeGeoLogInterval" supplier="cl_IfcGeoScienceObservationTypeEnum_BOREHOLELOG"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsBoreholeGeophysicalInterval" name="Pset_GeoObsBoreholeGeophysicalInterval">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsBoreholeGeophysicalInterval_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_BoreholeDiameter" name="BoreholeDiameter">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_BoreholeDiameter_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_BoreholeDiameter_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_DryBulkDensity" name="DryBulkDensity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcMassDensityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_DryBulkDensity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_DryBulkDensity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_GammaRay" name="GammaRay">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcReal"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_GammaRay_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_GammaRay_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_GroundwaterTemperature" name="GroundwaterTemperature">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcThermodynamicTemperatureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_GroundwaterTemperature_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_GroundwaterTemperature_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_PoissonRatio" name="PoissonRatio">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_PoissonRatio_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_PoissonRatio_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_PwaveVelocity" name="PwaveVelocity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLinearVelocityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_PwaveVelocity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_PwaveVelocity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_SpontaneousPotential" name="SpontaneousPotential">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcElectricVoltageMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_SpontaneousPotential_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_SpontaneousPotential_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_SwaveVelocity" name="SwaveVelocity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLinearVelocityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_SwaveVelocity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_SwaveVelocity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_WetBulkDensity" name="WetBulkDensity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_WetBulkDensity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_WetBulkDensity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_YoungModulus" name="YoungModulus">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcModulusOfElasticityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_YoungModulus_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeGeophysicalInterval_YoungModulus_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsBoreholeGeophysicalInterval_IfcGeoScienceObservationTypeEnum_BOREHOLELOG" client="cl_Pset_GeoObsBoreholeGeophysicalInterval" supplier="cl_IfcGeoScienceObservationTypeEnum_BOREHOLELOG"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsBoreholeMWDInterval" name="Pset_GeoObsBoreholeMWDInterval">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsBoreholeMWDInterval_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_Cracking" name="Cracking">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_Cracking_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_Cracking_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_Hardness" name="Hardness">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_Hardness_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_Hardness_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_WaterLeakage" name="WaterLeakage">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_WaterLeakage_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeMWDInterval_WaterLeakage_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsBoreholeMWDInterval_IfcGeoScienceObservationTypeEnum_BOREHOLELOG" client="cl_Pset_GeoObsBoreholeMWDInterval" supplier="cl_IfcGeoScienceObservationTypeEnum_BOREHOLELOG"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsBoreholeWaterLevel" name="Pset_GeoObsBoreholeWaterLevel">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsBoreholeWaterLevel_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeWaterLevel_IsPiezometric" name="IsPiezometric">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcBoolean"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeWaterLevel_IsPiezometric_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeWaterLevel_IsPiezometric_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsBoreholeWaterLevel_WaterLevel" name="WaterLevel">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsBoreholeWaterLevel_WaterLevel_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsBoreholeWaterLevel_WaterLevel_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsBoreholeWaterLevel_IfcGeoScienceObservationTypeEnum_BOREHOLELOG" client="cl_Pset_GeoObsBoreholeWaterLevel" supplier="cl_IfcGeoScienceObservationTypeEnum_BOREHOLELOG"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsCommon" name="Pset_GeoObsCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsCommon_Lithology" name="Lithology">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsCommon_Lithology_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsCommon_Lithology_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsCommon_ObservationEndDate" name="ObservationEndDate">
+        <type xmi:type="uml:DataType" href="IfcDateTimeResource.uml#dt_IfcDate"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsCommon_ObservationEndDate_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsCommon_ObservationEndDate_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsCommon_ObservationStartDate" name="ObservationStartDate">
+        <type xmi:type="uml:DataType" href="IfcDateTimeResource.uml#dt_IfcDate"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsCommon_ObservationStartDate_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsCommon_ObservationStartDate_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsCommon_IfcGeoScienceObservation" client="cl_Pset_GeoObsCommon" supplier="cl_IfcGeoScienceObservation"/>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsCommon_IfcBorehole" client="cl_Pset_GeoObsCommon" supplier="cl_IfcBorehole"/>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsCommon_IfcSensor" client="cl_Pset_GeoObsCommon">
+      <supplier xmi:type="uml:Class" href="IfcBuildingControlsDomain.uml#cl_IfcSensor"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsDiscontinuityCommon" name="Pset_GeoObsDiscontinuityCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsDiscontinuityCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DipAngle" name="DipAngle">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DipAngle_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DipAngle_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DipDirection" name="DipDirection">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DipDirection_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DipDirection_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityAperture" name="DiscontinuityAperture">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityAperture_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityAperture_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityCohesion" name="DiscontinuityCohesion">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityCohesion_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityCohesion_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityFrictionAngle" name="DiscontinuityFrictionAngle">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityFrictionAngle_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityFrictionAngle_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityInFilling" name="DiscontinuityInFilling">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityInFilling_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityInFilling_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityPersistence" name="DiscontinuityPersistence">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityPersistence_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityPersistence_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityRoughness" name="DiscontinuityRoughness">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityRoughness_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityRoughness_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuitySpacing" name="DiscontinuitySpacing">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuitySpacing_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuitySpacing_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityType" name="DiscontinuityType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityWaterSeepage" name="DiscontinuityWaterSeepage">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityWaterSeepage_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityCommon_DiscontinuityWaterSeepage_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsDiscontinuityCommon_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" client="cl_Pset_GeoObsDiscontinuityCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE"/>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsDiscontinuityCommon_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION" client="cl_Pset_GeoObsDiscontinuityCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsDiscontinuityFault" name="Pset_GeoObsDiscontinuityFault">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsDiscontinuityFault_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityFault_DeformationPhase" name="DeformationPhase">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityFault_DeformationPhase_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityFault_DeformationPhase_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityFault_Displacement" name="Displacement">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityFault_Displacement_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityFault_Displacement_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultLength" name="FaultLength">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultLength_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultLength_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultPitchAngle" name="FaultPitchAngle">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultPitchAngle_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultPitchAngle_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultSlipDirection" name="FaultSlipDirection">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultSlipDirection_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultSlipDirection_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultThickness" name="FaultThickness">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcNonNegativeLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultThickness_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultThickness_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultType" name="FaultType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsDiscontinuityFault_FaultType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsDiscontinuityFault_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" client="cl_Pset_GeoObsDiscontinuityFault" supplier="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE"/>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsDiscontinuityFault_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION" client="cl_Pset_GeoObsDiscontinuityFault" supplier="cl_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsFoldAxis" name="Pset_GeoObsFoldAxis">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsFoldAxis_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsFoldAxis_AzimuthHingeLine" name="AzimuthHingeLine">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsFoldAxis_AzimuthHingeLine_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsFoldAxis_AzimuthHingeLine_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsFoldAxis_AzimuthHingeLineation" name="AzimuthHingeLineation">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsFoldAxis_AzimuthHingeLineation_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsFoldAxis_AzimuthHingeLineation_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsFoldAxis_DeformationPhase" name="DeformationPhase">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsFoldAxis_DeformationPhase_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsFoldAxis_DeformationPhase_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsFoldAxis_FoldType" name="FoldType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsFoldAxis_FoldType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsFoldAxis_FoldType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsFoldAxis_Plunge" name="Plunge">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsFoldAxis_Plunge_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsFoldAxis_Plunge_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsFoldAxis_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" client="cl_Pset_GeoObsFoldAxis" supplier="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsHydroGeologyWaterInflow" name="Pset_GeoObsHydroGeologyWaterInflow">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsHydroGeologyWaterInflow_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_InflowRate" name="InflowRate">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcVolumetricFlowRateMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_InflowRate_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_InflowRate_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_InflowSum" name="InflowSum">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcVolumeMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_InflowSum_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_InflowSum_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_SourceArea" name="SourceArea">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_SourceArea_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_SourceArea_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_SourceType" name="SourceType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_SourceType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsHydroGeologyWaterInflow_SourceType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsHydroGeologyWaterInflow_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION" client="cl_Pset_GeoObsHydroGeologyWaterInflow" supplier="cl_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsLineation" name="Pset_GeoObsLineation">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsLineation_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsLineation_DefiningElement" name="DefiningElement">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsLineation_DefiningElement_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsLineation_DefiningElement_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsLineation_DeformationPhase" name="DeformationPhase">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsLineation_DeformationPhase_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsLineation_DeformationPhase_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsLineation_DipDirection" name="DipDirection">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsLineation_DipDirection_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsLineation_DipDirection_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsLineation_LineationType" name="LineationType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsLineation_LineationType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsLineation_LineationType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsLineation_Plunge" name="Plunge">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsLineation_Plunge_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsLineation_Plunge_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsLineation_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" client="cl_Pset_GeoObsLineation" supplier="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsMappedUnit" name="Pset_GeoObsMappedUnit">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsMappedUnit_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_AreaID" name="AreaID">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcIdentifier"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_AreaID_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_AreaID_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_CoveragePercentage" name="CoveragePercentage">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_CoveragePercentage_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_CoveragePercentage_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_DiscontinuitySpacing" name="DiscontinuitySpacing" type="en_PEnum_DiscontinuitySpacing">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_DiscontinuitySpacing_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_DiscontinuitySpacing_upper" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_GSI" name="GSI">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_GSI_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_GSI_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_QValue" name="QValue">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcReal"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_QValue_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_QValue_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_RMR" name="RMR">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_RMR_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_RMR_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_Weathering" name="Weathering" type="en_PEnum_Weathering">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_Weathering_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_Weathering_upper" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_DiscontinuitySpacing" name="PEnum_DiscontinuitySpacing">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_EXTREMELY_CLOSE" name="EXTREMELY_CLOSE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_VERY_CLOSE" name="VERY_CLOSE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_CLOSE" name="CLOSE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_MEDIUM" name="MEDIUM"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_WIDE" name="WIDE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_DiscontinuitySpacing_VERY_WIDE" name="VERY_WIDE"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_Weathering" name="PEnum_Weathering">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_FRESH" name="FRESH"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_DISCOLOURED" name="DISCOLOURED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_DISINTEGRATED" name="DISINTEGRATED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_DECOMPOSED" name="DECOMPOSED"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsMappedUnit_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" client="cl_Pset_GeoObsMappedUnit" supplier="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsPtObservationCommon" name="Pset_GeoObsPtObservationCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeoObsPtObservationCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_Boulders" name="Boulders">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_Boulders_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_Boulders_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_GasConcentration" name="GasConcentration">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_GasConcentration_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_GasConcentration_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_GasType" name="GasType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_GasType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_GasType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundTemperature" name="GroundTemperature">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcThermodynamicTemperatureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundTemperature_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundTemperature_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundwaterAgressiveness" name="GroundwaterAgressiveness">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundwaterAgressiveness_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundwaterAgressiveness_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundwaterTemperature" name="GroundwaterTemperature">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcThermodynamicTemperatureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundwaterTemperature_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_GroundwaterTemperature_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_Karst" name="Karst">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_Karst_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_Karst_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_Veining" name="Veining">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_Veining_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_Veining_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsPtObservationCommon_Weathering" name="Weathering">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsPtObservationCommon_Weathering_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsPtObservationCommon_Weathering_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsPtObservationCommon_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION" client="cl_Pset_GeoObsPtObservationCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_LOCALINFORMATION"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeophysicalSurveyBorehole" name="Pset_GeophysicalSurveyBorehole">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeophysicalSurveyBorehole_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeophysicalSurveyBorehole_BoreholeGeophysConfiguration" name="BoreholeGeophysConfiguration">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeophysicalSurveyBorehole_BoreholeGeophysConfiguration_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeophysicalSurveyBorehole_BoreholeGeophysConfiguration_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeophysicalSurveyBorehole_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT" client="cl_Pset_GeophysicalSurveyBorehole" supplier="cl_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeophysicalSurveyCommon" name="Pset_GeophysicalSurveyCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_GeophysicalSurveyCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyDimension" name="SurveyDimension">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyDimension_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyDimension_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyInstrumentManufacturer" name="SurveyInstrumentManufacturer">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyInstrumentManufacturer_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyInstrumentManufacturer_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyInstrumentModel" name="SurveyInstrumentModel">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyInstrumentModel_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyInstrumentModel_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyMethod" name="SurveyMethod" type="en_PEnum_GeophysicalSurveyMethod">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyMethod_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeophysicalSurveyCommon_SurveyMethod_upper" value="*"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="en_PEnum_GeophysicalSurveyMethod" name="PEnum_GeophysicalSurveyMethod">
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_REFLECTION_SEISMIC" name="REFLECTION_SEISMIC"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_REFRACTION_SEISMIC" name="REFRACTION_SEISMIC"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_SURFACEWAVE_SEISMIC" name="SURFACEWAVE_SEISMIC"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_PASSIVE_SEISMIC" name="PASSIVE_SEISMIC"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_OTHER_SEISMIC" name="OTHER_SEISMIC"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_ELECTRICAL" name="ELECTRICAL"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_ELECTROMAGNETIC" name="ELECTROMAGNETIC"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_RADAR" name="RADAR"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_GRAVITY" name="GRAVITY"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_MAGNETIC" name="MAGNETIC"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_NMR" name="NMR"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeophysicalSurveyCommon_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT" client="cl_Pset_GeophysicalSurveyCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_InSituTestCPT" name="Pset_InSituTestCPT">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_InSituTestCPT_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestCPT_CPTConeResistance" name="CPTConeResistance">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestCPT_CPTConeResistance_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestCPT_CPTConeResistance_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestCPT_CPTLocalSideFriction" name="CPTLocalSideFriction">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestCPT_CPTLocalSideFriction_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestCPT_CPTLocalSideFriction_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestCPT_CPTPorePressure" name="CPTPorePressure">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestCPT_CPTPorePressure_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestCPT_CPTPorePressure_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestCPT_YoungModulus" name="YoungModulus">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcModulusOfElasticityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestCPT_YoungModulus_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestCPT_YoungModulus_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_InSituTestCPT_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" client="cl_Pset_InSituTestCPT" supplier="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_InSituTestCommon" name="Pset_InSituTestCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_InSituTestCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestCommon_TestDepthRange" name="TestDepthRange">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcNonNegativeLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestCommon_TestDepthRange_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestCommon_TestDepthRange_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestCommon_TestMethod" name="TestMethod">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestCommon_TestMethod_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestCommon_TestMethod_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestCommon_TestType" name="TestType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestCommon_TestType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestCommon_TestType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_InSituTestCommon_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" client="cl_Pset_InSituTestCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_InSituTestHydro" name="Pset_InSituTestHydro">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_InSituTestHydro_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestHydro_HydraulicConductivity" name="HydraulicConductivity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLinearVelocityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestHydro_HydraulicConductivity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestHydro_HydraulicConductivity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestHydro_HydraulicPermeability" name="HydraulicPermeability">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLinearVelocityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestHydro_HydraulicPermeability_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestHydro_HydraulicPermeability_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestHydro_LugeonValue" name="LugeonValue">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestHydro_LugeonValue_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestHydro_LugeonValue_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestHydro_Storativity" name="Storativity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestHydro_Storativity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestHydro_Storativity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_InSituTestHydro_Transmissivity" name="Transmissivity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcReal"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_InSituTestHydro_Transmissivity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_InSituTestHydro_Transmissivity_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_InSituTestHydro_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" client="cl_Pset_InSituTestHydro" supplier="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_LabTestCommon" name="Pset_LabTestCommon">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_LabTestCommon_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestCommon_TestMethod" name="TestMethod">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestCommon_TestMethod_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestCommon_TestMethod_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestCommon_TestStandard" name="TestStandard">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestCommon_TestStandard_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestCommon_TestStandard_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestCommon_TestType" name="TestType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestCommon_TestType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestCommon_TestType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_LabTestCommon_IfcGeoScienceObservationTypeEnum_LABTESTRESULT" client="cl_Pset_LabTestCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_LABTESTRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_LabTestResult" name="Pset_LabTestResult">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_LabTestResult_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_CohesionBehaviour" name="CohesionBehaviour">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_CohesionBehaviour_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_CohesionBehaviour_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_FrictionAngle" name="FrictionAngle">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPlaneAngleMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_FrictionAngle_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_FrictionAngle_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_HydraulicConductivity" name="HydraulicConductivity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLinearVelocityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_HydraulicConductivity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_HydraulicConductivity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_LiquidLimits" name="LiquidLimits">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_LiquidLimits_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_LiquidLimits_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_MassDensity" name="MassDensity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcMassDensityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_MassDensity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_MassDensity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_PlasticityIndex" name="PlasticityIndex">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_PlasticityIndex_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_PlasticityIndex_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_PlasticLimit" name="PlasticLimit">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_PlasticLimit_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_PlasticLimit_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_Porosity" name="Porosity">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_Porosity_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_Porosity_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_Slaking" name="Slaking">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_Slaking_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_Slaking_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_TestedMaterial" name="TestedMaterial">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_TestedMaterial_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_TestedMaterial_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_UnconfinedCompressiveStrength" name="UnconfinedCompressiveStrength">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPressureMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_UnconfinedCompressiveStrength_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_UnconfinedCompressiveStrength_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_WaterContent" name="WaterContent">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveRatioMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_WaterContent_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_WaterContent_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_LabTestResult_YoungModulus" name="YoungModulus">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcModulusOfElasticityMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_LabTestResult_YoungModulus_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_LabTestResult_YoungModulus_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_LabTestResult_IfcGeoScienceObservationTypeEnum_LABTESTRESULT" client="cl_Pset_LabTestResult" supplier="cl_IfcGeoScienceObservationTypeEnum_LABTESTRESULT"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_SpatialGeoObsSample" name="Pset_SpatialGeoObsSample">
+      <ownedComment xmi:type="uml:Comment" xmi:id="cl_Pset_SpatialGeoObsSample_comment_0">
+        <body>PSET_TYPEDRIVENOVERRIDE</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SpatialGeoObsSample_SampleBoreholeDepthRange" name="SampleBoreholeDepthRange">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcNonNegativeLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SpatialGeoObsSample_SampleBoreholeDepthRange_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SpatialGeoObsSample_SampleBoreholeDepthRange_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SpatialGeoObsSample_SampleProcedure" name="SampleProcedure">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcText"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SpatialGeoObsSample_SampleProcedure_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SpatialGeoObsSample_SampleProcedure_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SpatialGeoObsSample_SamplePurpose" name="SamplePurpose">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SpatialGeoObsSample_SamplePurpose_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SpatialGeoObsSample_SamplePurpose_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SpatialGeoObsSample_SampleType" name="SampleType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SpatialGeoObsSample_SampleType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SpatialGeoObsSample_SampleType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_SpatialGeoObsSample_SamplingPointType" name="SamplingPointType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_SpatialGeoObsSample_SamplingPointType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_SpatialGeoObsSample_SamplingPointType_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_SpatialGeoObsSample_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT" client="cl_Pset_SpatialGeoObsSample" supplier="cl_IfcGeoScienceObservationTypeEnum_INSITUTESTRESULT"/>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_SpatialGeoObsSample_IfcGeoScienceObservationTypeEnum_LABTESTRESULT" client="cl_Pset_SpatialGeoObsSample" supplier="cl_IfcGeoScienceObservationTypeEnum_LABTESTRESULT"/>
   </packagedElement>
 </uml:Model>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1873,6 +1873,9 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_GRAVITY" name="GRAVITY"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_MAGNETIC" name="MAGNETIC"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_NMR" name="NMR"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_GeophysicalSurveyMethod_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeophysicalSurveyCommon_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT" client="cl_Pset_GeophysicalSurveyCommon" supplier="cl_IfcGeoScienceObservationTypeEnum_GEOPHYSICALSURVEYRESULT"/>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_InSituTestCPT" name="Pset_InSituTestCPT">

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1773,6 +1773,9 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_DISCOLOURED" name="DISCOLOURED"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_DISINTEGRATED" name="DISINTEGRATED"/>
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_DECOMPOSED" name="DECOMPOSED"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_OTHER" name="OTHER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_NOTKNOWN" name="NOTKNOWN"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_PEnum_Weathering_UNSET" name="UNSET"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Pset_GeoObsMappedUnit_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE" client="cl_Pset_GeoObsMappedUnit" supplier="cl_IfcGeoScienceObservationTypeEnum_MAPPEDFEATURE"/>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_Pset_GeoObsPtObservationCommon" name="Pset_GeoObsPtObservationCommon">

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1737,7 +1737,7 @@
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_DiscontinuitySpacing_lower" value="1"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_DiscontinuitySpacing_upper" value="*"/>
       </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_GSI" name="GSI">
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_GSI" name="GeologicalStrengthIndex">
         <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_GSI_lower"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_GSI_upper" value="1"/>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -1747,7 +1747,7 @@
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_QValue_lower"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_QValue_upper" value="1"/>
       </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_RMR" name="RMR">
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_Pset_GeoObsMappedUnit_RMR" name="RockMassRating">
         <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_Pset_GeoObsMappedUnit_RMR_lower"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_Pset_GeoObsMappedUnit_RMR_upper" value="1"/>


### PR DESCRIPTION
## Summary

TM20 introduces the observation product hierarchy and a set of geoscientific
property sets, plus an adapted formal rule on `IfcRelAssociatesMaterial`.

**Scope:** ENTITY IfcComplementaryData, ENTITY IfcObservation, ENTITY
IfcGeoScienceObservation, TYPE IfcGeoScienceObservationTypeEnum, WHERE
IfcRelAssociatesMaterial.AllowedElements.

## What landed

**Entities + type:**
- `IfcComplementaryData` (ABSTRACT, SUBTYPE OF `IfcProduct`)
- `IfcObservation` (SUBTYPE OF `IfcComplementaryData`)
- `IfcGeoScienceObservation` (SUBTYPE OF `IfcObservation`) — geoscientific observation with `PredefinedType` and a `HasObjectType` WHERE rule.
- `IfcGeoScienceObservationTypeEnum` — 8 values (INSITUTESTRESULT, LABTESTRESULT, BOREHOLELOG, MAPPEDFEATURE, LOCALINFORMATION, GEOPHYSICALSURVEYRESULT, USERDEFINED, NOTDEFINED).

**WHERE rule update:** `IfcRelAssociatesMaterial.AllowedElements` extended to admit `IfcGeoScienceObservation`.

**Property sets (23 new), applicable to `IfcGeoScienceObservation`:**
- Pset_BoreholeTestPressuremeter, Pset_BoreholeTestSPT
- Pset_GeoObsBoreholeCommon, Pset_GeoObsBoreholeGeoLogInterval, Pset_GeoObsBoreholeGeophysicalInterval, Pset_GeoObsBoreholeMWDInterval, Pset_GeoObsBoreholeWaterLevel
- Pset_GeoObsCommon
- Pset_GeoObsDiscontinuityCommon, Pset_GeoObsDiscontinuityFault
- Pset_GeoObsFoldAxis, Pset_GeoObsHydroGeologyWaterInflow, Pset_GeoObsLineation
- Pset_GeoObsMappedUnit, Pset_GeoObsPtObservationCommon
- Pset_GeophysicalSurveyBorehole, Pset_GeophysicalSurveyCommon
- Pset_InSituTestCommon, Pset_InSituTestCPT, Pset_InSituTestHydro
- Pset_LabTestCommon, Pset_LabTestResult
- Pset_SpatialGeoObsSample

**Property enumerations (3 new):** `PEnum_DiscontinuitySpacing`, `PEnum_GeophysicalSurveyMethod`, `PEnum_Weathering`.
